### PR TITLE
cancelDraw endpoint and FreehandMouseTool support for cancelling draw

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,7 @@ import { playClip, stopClip } from './stackTools/playClip.js';
 
 // ~~~~~~ STATE MANAGEMENT ~~~~~ //
 import { default as store } from './store/index.js';
+import { default as cancelDrawing } from './store/cancelDrawing.js';
 import { default as getToolForElement } from './store/getToolForElement.js';
 import { addTool, addToolForElement } from './store/addTool.js';
 import { removeTool, removeToolForElement } from './store/removeTool.js';
@@ -242,6 +243,7 @@ const cornerstoneTools = {
   playClip,
   stopClip,
   store,
+  cancelDrawing,
   getToolForElement,
   addTool,
   addToolForElement,
@@ -341,6 +343,7 @@ export {
   playClip,
   stopClip,
   store,
+  cancelDrawing,
   getToolForElement,
   addTool,
   addToolForElement,

--- a/src/store/cancelDrawing.js
+++ b/src/store/cancelDrawing.js
@@ -1,0 +1,18 @@
+import { state } from './index.js';
+
+/**
+ * Calls cancelDrawing on all tools.
+ * @export
+ * @public
+ * @method
+ * @name cancelDrawing
+ *
+ * @returns {undefined}
+ */
+export default function cancelDrawing() {
+  state.tools.forEach(tool => {
+    if (Object.prototype.hasOwnProperty.call(tool, 'cancelDrawing')) {
+      tool.cancelDrawing();
+    }
+  });
+}

--- a/src/store/cancelDrawing.js
+++ b/src/store/cancelDrawing.js
@@ -11,7 +11,10 @@ import { state } from './index.js';
  */
 export default function cancelDrawing() {
   state.tools.forEach(tool => {
-    if (Object.prototype.hasOwnProperty.call(tool, 'cancelDrawing')) {
+    if (
+      tool.mode === 'active' &&
+      Object.prototype.hasOwnProperty.call(tool, 'cancelDrawing')
+    ) {
       tool.cancelDrawing();
     }
   });


### PR DESCRIPTION
This pull requests fixes the command line issues related to deleting an unfinished drawing element and cancelling the active draw.

It does not fix the AngleTool, which doesn't have a good way to stop the drawing operation in the middle.

Tools that have only two points shouldn't have any problems.

Contributes to https://github.com/trustsitka/sitka/issues/3417