### PR TITLE
Restore StackScrollMouseWheel when Pan/Zoom deactivates

### DIFF
--- a/src/tools/PanZoomTool.js
+++ b/src/tools/PanZoomTool.js
@@ -21,6 +21,7 @@ export default class PanZoomTool extends BaseTool {
 
     this.referencedToolNames = {
       pan: 'Pan',
+      stackScrollWheel: 'StackScrollMouseWheel',
       zoomWheel: 'ZoomMouseWheel',
     };
   }
@@ -32,5 +33,13 @@ export default class PanZoomTool extends BaseTool {
 
   passiveCallback() {
     setToolPassive(this.referencedToolNames.zoomWheel);
+
+    // TODO: Temporary workaround re-enabling stack scrolling
+    // with mouse wheel when Pan/Zoom is disabled. Ideally
+    // we should figure a way to define constant defaults for masks
+    // for when no tools are active.
+    setToolActive(this.referencedToolNames.stackScrollWheel, {
+      mouseButtonMask: 4,
+    });
   }
 }


### PR DESCRIPTION
Mouse-wheel stacking scrolling is the default action masked to the mouse wheel (or two finger touchpad drag) when the Viewer loads. However, the behavior does not persist after any tool that masks the mouse wheel is activated. Currently he only tool that masks mouse wheel scroll is Pan/Zoom so for now we can get away with manually re-enabling StackScrollMouseWheel when Pan/Zoom deactivates. 

Longer term we'll probably want to figure out how to have default masks persist when no tool is active. I'll open an issue in the OHIF/Viewers repo.